### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-documentation-site.yml
+++ b/.github/workflows/update-documentation-site.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5.0.0
 


### PR DESCRIPTION
Potential fix for [https://github.com/gplint/gplint/security/code-scanning/8](https://github.com/gplint/gplint/security/code-scanning/8)

To fix the problem, you should add an explicit `permissions` block specifying the minimum set of OAuth scopes the workflow job needs. In most cases, if your workflow does not need to write to the repository, you can use `contents: read` as a starting point. If you need additional write privileges for issues, pull requests, etc., those should be added explicitly. For this workflow, the only repository operation shown is a call to the GitHub API using a personal access token (PAT), which does not require GITHUB_TOKEN write access, and a checkout (typically read-only); so `contents: read` will suffice. You should add the `permissions` block either at the workflow root or just under the `publish` job (line 12). For clarity, adding under the job is recommended here.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
