### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    permissions:
+      contents: read
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/gplint/gplint/security/code-scanning/7](https://github.com/gplint/gplint/security/code-scanning/7)

To fix the problem, add a `permissions` block granting only the minimum required privileges for the job to run successfully. The recommended minimal permission for most CI workflows is `contents: read`, which allows checkout and reading repository contents without permitting writes. This should be added either at the workflow root or at the job level. Since this workflow consists only of a single job and does not appear to require any additional permissions, adding the block at the job level (inside `build:`) ensures clarity and specificity. The edit should be made before `runs-on: ${{ matrix.os }}` (i.e., between lines 16 and 18) in `.github/workflows/test.yml`.

No additional methods, imports, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
