### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,6 +23,9 @@ env:
   GIT_USER_NAME: 'Luis Zurro de Cos'
   GIT_USER_EMAIL: '1042532+Nyaran@users.noreply.github.com'
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gplint/gplint/security/code-scanning/6](https://github.com/gplint/gplint/security/code-scanning/6)

To fix the issue, add a `permissions` block either at the root of the workflow file (to apply to all jobs, unless overridden), or at the job level (for finer control). The minimum required for this workflow are: `contents: read` for source code access, and `pull-requests: write` to create PRs via `peter-evans/create-pull-request`. Place the permissions block above the `jobs` key (to cover all jobs) or inside the `release` job. No changes to the workflow steps or secrets are required, only the addition of the permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
