### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if:  startsWith(github.head_ref, 'release/')
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/gplint/gplint/security/code-scanning/5](https://github.com/gplint/gplint/security/code-scanning/5)

To fix the problem, we should add an explicit `permissions` block to the job (or at the workflow root) to limit the GITHUB_TOKEN capabilities to only those needed for the workflow. Since the job uses `softprops/action-gh-release` to create a release, it needs `contents: write`. The other steps (checkout, setup-node, npm install, etc.) do not require additional repository permissions. Adding `permissions: contents: write` to the `release` job (under line 11) is the minimal change, as only this job needs the permission for release creation. No new imports, external dependencies, or other file changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
