### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/gplint/gplint/security/code-scanning/4](https://github.com/gplint/gplint/security/code-scanning/4)

The best way to fix the problem is to explicitly set a `permissions:` block for the job (or at the root of the workflow) to restrict the GITHUB_TOKEN to the minimal required permissions. Since this workflow uses external tokens/secrets for its sensitive operations (publishing to npm and triggering workflow dispatch on another repo via the PAT), it appears that none of the job steps require write access via GITHUB_TOKEN; thus, the minimal permission of `contents: read` is adequate to mitigate risk. You should add `permissions: contents: read` to the `publish` job (just above `runs-on: ubuntu-latest`, at line 9), or to the root of the workflow for global effect. This does not otherwise modify the workflow's logic, only the permissions granted to GITHUB_TOKEN.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
