### PR TITLE
feat(table-align): add autofix support

### DIFF
--- a/src/rules/table-align.ts
+++ b/src/rules/table-align.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {GherkinData, RuleSubConfig, RuleError, ErrorData, Documentation} from '../types.js';
+import {GherkinData, RuleSubConfig, RuleError, ErrorData, FileData, Documentation} from '../types.js';
 import {TableRow} from '@cucumber/messages';
 import { featureSpread } from './utils/gherkin.js';
 
@@ -13,7 +13,8 @@ export const availableConfigs = {
 };
 
 interface TableAlignErrorData extends ErrorData {
-	value: string
+	value: string,
+	expectedLine: string,
 }
 
 export function run({feature, file}: GherkinData, configuration: RuleSubConfig<typeof availableConfigs>): TableAlignErrorData[] {
@@ -31,8 +32,21 @@ export function run({feature, file}: GherkinData, configuration: RuleSubConfig<t
 		const columnsMaxLength = columns.map(column => Math.max(...column.map(cell => cell.trim().length)));
 
 		rows.forEach((row, rowIndex) => {
-			const realLine = _.trim(file.lines[row.location.line - 1].trim(), TABLE_SEPARATOR);
+			const line = file.lines[row.location.line - 1];
+			const realLine = _.trim(line.trim(), TABLE_SEPARATOR);
 			const realCells = realLine.split(TABLE_SPLITTER);
+
+			// Build the fully aligned version of this row now and attach it to each
+			// cell error, since `fix` only gets the error and can't see the table.
+			// Keep the row's original indentation — lining up indentation is the
+			// indentation rule's job. Use the cell text straight from the source
+			// line, not row.cells[].value: the parser strips the backslash from an
+			// escaped pipe (`\|` becomes `|`), which would throw off the column
+			// widths and mean fixing a table with escaped pipes never settles.
+			const indent = line.substring(0, line.length - line.trimStart().length);
+			const expectedLine = indent + TABLE_SEPARATOR + tableLines[rowIndex]
+				.map((cell, cellIndex) => ` ${cell.trim().padEnd(columnsMaxLength[cellIndex])} `)
+				.join(TABLE_SEPARATOR) + TABLE_SEPARATOR;
 
 			row.cells.forEach((cell, cellIndex) => {
 				const cellValue = tableLines[rowIndex][cellIndex].trim();
@@ -42,6 +56,7 @@ export function run({feature, file}: GherkinData, configuration: RuleSubConfig<t
 					errors.push({
 						location: cell.location,
 						value: cellValue,
+						expectedLine,
 					});
 				}
 			});
@@ -83,6 +98,12 @@ export function buildRuleErrors(error: TableAlignErrorData): RuleError {
 		line: error.location.line,
 		column: error.location.column,
 	};
+}
+
+export function fix(error: TableAlignErrorData, file: FileData): void {
+	// Same-row cell errors all carry the identical expectedLine, so rewriting
+	// the line once per error is idempotent.
+	file.lines[error.location.line - 1] = error.expectedLine;
 }
 
 function _splitTableRow(line: string): string[] {

--- a/src/rules/table-align.ts
+++ b/src/rules/table-align.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import {GherkinData, RuleSubConfig, RuleError, Documentation} from '../types.js';
-import {TableCell, TableRow} from '@cucumber/messages';
+import {GherkinData, RuleSubConfig, RuleError, ErrorData, Documentation} from '../types.js';
+import {TableRow} from '@cucumber/messages';
 import { featureSpread } from './utils/gherkin.js';
 
 const TABLE_SEPARATOR = '|';
@@ -12,7 +12,11 @@ export const availableConfigs = {
 	steps: true,
 };
 
-export function run({feature, file}: GherkinData, configuration: RuleSubConfig<typeof availableConfigs>): RuleError[] {
+interface TableAlignErrorData extends ErrorData {
+	value: string
+}
+
+export function run({feature, file}: GherkinData, configuration: RuleSubConfig<typeof availableConfigs>): TableAlignErrorData[] {
 	function _checkRows(rows: readonly TableRow[]) {
 		// row could be null on missing tables
 		if (rows.length === 0 || rows.some(row => row == null)) {
@@ -35,10 +39,10 @@ export function run({feature, file}: GherkinData, configuration: RuleSubConfig<t
 				const expectedCellValue = ` ${cellValue.padEnd(columnsMaxLength[cellIndex])} `;
 
 				if (expectedCellValue !== realCells[cellIndex]) {
-					errors.push(createError({
+					errors.push({
 						location: cell.location,
-						value: cellValue
-					}));
+						value: cellValue,
+					});
 				}
 			});
 		});
@@ -49,7 +53,7 @@ export function run({feature, file}: GherkinData, configuration: RuleSubConfig<t
 	}
 	const mergedConfig = _.merge({}, availableConfigs, configuration);
 
-	const errors = [] as RuleError[];
+	const errors = [] as TableAlignErrorData[];
 
 	const {children} = featureSpread(feature);
 
@@ -72,12 +76,12 @@ export function run({feature, file}: GherkinData, configuration: RuleSubConfig<t
 	return errors;
 }
 
-function createError(cell: TableCell): RuleError {
+export function buildRuleErrors(error: TableAlignErrorData): RuleError {
 	return {
-		message: `Cell with value "${cell.value}" is not aligned`,
+		message: `Cell with value "${error.value}" is not aligned`,
 		rule: name,
-		line: cell.location.line,
-		column: cell.location.column,
+		line: error.location.line,
+		column: error.location.column,
 	};
 }
 

--- a/test/rules/table-align/rule.feature
+++ b/test/rules/table-align/rule.feature
@@ -1,0 +1,7 @@
+Feature: Feature with a Rule block
+
+  Rule: This is a Rule
+    Scenario: This is a Scenario
+      Given step with table:
+        |lorem|ipsum|
+        |foo|bar baz|

--- a/test/rules/table-align/single-cell.feature
+++ b/test/rules/table-align/single-cell.feature
@@ -1,0 +1,6 @@
+Feature: Feature with a single misaligned cell
+
+  Scenario: This is a Scenario
+    Given step with table:
+      | aa | b |
+      | a  | bb |

--- a/test/rules/table-align/table-align.ts
+++ b/test/rules/table-align/table-align.ts
@@ -1,7 +1,14 @@
+import {assert} from 'chai';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import * as ruleTestBase from '../rule-test-base.js';
+import * as linter from '../../../src/linter.js';
+import {stringEOLNormalize} from '../../_test_utils.js';
 import * as rule from '../../../src/rules/table-align.js';
 const runTest = ruleTestBase.createRuleTest(rule,
 	'Cell with value "<%= cellValue %>" is not aligned');
+const runFixTest = ruleTestBase.createRuleFixTest(rule);
 
 describe('Table Align Rule', function() {
 	it('doesn\'t raise errors when there are no violations', function() {
@@ -213,6 +220,43 @@ describe('Table Align Rule', function() {
 		]);
 	});
 
+	it('detects misalignment in tables nested under a Rule', function() {
+		return runTest('table-align/rule.feature', {}, [
+			// Step - First row
+			{
+				messageElements: {cellValue: 'lorem'},
+				line: 6,
+				column: 10,
+			},
+			{
+				messageElements: {cellValue: 'ipsum'},
+				line: 6,
+				column: 16,
+			},
+			// Step - Second row
+			{
+				messageElements: {cellValue: 'foo'},
+				line: 7,
+				column: 10,
+			},
+			{
+				messageElements: {cellValue: 'bar baz'},
+				line: 7,
+				column: 14,
+			},
+		]);
+	});
+
+	it('reports only the misaligned cell when the rest of the row is aligned', function() {
+		return runTest('table-align/single-cell.feature', {}, [
+			{
+				messageElements: {cellValue: 'b'},
+				line: 5,
+				column: 14,
+			},
+		]);
+	});
+
 	describe('tables without spaces - config', function() {
 		it('only steps', function() {
 			return runTest('table-align/simple-config.feature', {examples: false}, [
@@ -246,5 +290,186 @@ describe('Table Align Rule', function() {
 				},
 			]);
 		});
+	});
+});
+
+describe('Table Align Rule - fix line', function() {
+	it('leaves already-aligned tables untouched', function() {
+		return runFixTest('table-align/aligned.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with tables aligned
+
+  Background: This is a background
+    Given step with table in background:
+      | gplint   |
+      | do magic |
+
+  Scenario: This is a Scenario
+    Given step with table:
+      | lorem | ipsum | dolor   |
+      | foo   | bar   | foo bar |
+    When step without table
+
+  Scenario Outline: This is a Scenario Outline
+    Given test step <foo>
+    Examples:
+      | foo | lorem |
+      | bar |       |
+`));
+	});
+
+	it('aligns tables without spaces', function() {
+		return runFixTest('table-align/no-spaces.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with tables without spaces
+
+Background: This is a background
+  Given step with table in background:
+    | gplint   |
+    | do magic |
+
+Scenario: This is a Scenario
+  Given step with table:
+    | lorem | ipsum | dolor   |
+    | foo   | bar   | foo bar |
+  When step without table
+
+Scenario Outline: This is a Scenario Outline
+  Given test step <foo>
+Examples:
+  | foo | lorem |
+  | bar |       |
+`));
+	});
+
+	it('aligns tables with crazy spacing', function() {
+		return runFixTest('table-align/crazy-spaces.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with tables with crazy spacing
+
+Background: This is a background
+  Given step with table in background:
+    | gplint   |
+    | do magic |
+
+Scenario: This is a Scenario
+  Given step with table:
+    | lorem | ipsum | dolor   |
+    | foo   | bar   | foo bar |
+  When step without table
+
+Scenario Outline: This is a Scenario Outline
+  Given test step <foo>
+Examples:
+  | foo | lorem |
+  | bar |       |
+`));
+	});
+
+	it('aligns tables with escaped characters (escape-aware column widths)', function() {
+		return runFixTest('table-align/escape.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with tables with pipe symbols
+
+  Scenario: This is a Scenario
+    Given step with escaped pipes:
+      | \\|this | \\| is \\|    | aligned\\|   |
+      | \\|this | \\| isn't \\| | aligned\\|   |
+      | this   | \\|is\\|      | aligned too |
+    And step with backslashes:
+      | \\this | \\ is \\    | aligned\\    |
+      | \\this | \\ isn't \\ | aligned\\    |
+      | this  | \\is\\      | aligned too |
+    And step with escaped backslashes:
+      | \\\\this | \\\\ is \\\\    | aligned\\\\   |
+      | \\\\this | \\\\ isn't \\\\ | aligned\\\\   |
+      | this   | \\\\is\\\\      | aligned too |
+`));
+	});
+
+	describe('respects config', function() {
+		it('only rewrites steps when examples are disabled', function() {
+			return runFixTest('table-align/simple-config.feature', {examples: false}, stringEOLNormalize(
+				// language=gherkin
+				`Feature: Feature with tables without spaces - Simple to use for config tests
+
+Scenario Outline: This is a Scenario Outline
+  Given step with table:
+    | lorem        |
+    | <loremipsum> |
+Examples:
+  |loremipsum|
+  ||
+`));
+		});
+
+		it('only rewrites examples when steps are disabled', function() {
+			return runFixTest('table-align/simple-config.feature', {steps: false}, stringEOLNormalize(
+				// language=gherkin
+				`Feature: Feature with tables without spaces - Simple to use for config tests
+
+Scenario Outline: This is a Scenario Outline
+  Given step with table:
+    |lorem|
+    |<loremipsum>|
+Examples:
+  | loremipsum |
+  |            |
+`));
+		});
+	});
+
+	it('aligns columns but preserves each row\'s original indentation', function() {
+		// Indentation is the indentation rule's job; table-align only aligns
+		// columns. The two rows keep their (different, odd) leading indents.
+		return runFixTest('table-align/weird-indent.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with oddly-indented tables
+
+  Scenario: This is a Scenario
+    Given step with an over-indented table:
+            | a   | bb |
+      | ccc | d  |
+`));
+	});
+
+	it('aligns tables nested under a Rule', function() {
+		return runFixTest('table-align/rule.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with a Rule block
+
+  Rule: This is a Rule
+    Scenario: This is a Scenario
+      Given step with table:
+        | lorem | ipsum   |
+        | foo   | bar baz |
+`));
+	});
+
+	it('canonicalizes the whole row from a single misaligned cell, leaving aligned rows untouched', function() {
+		return runFixTest('table-align/single-cell.feature', {}, stringEOLNormalize(
+			// language=gherkin
+			`Feature: Feature with a single misaligned cell
+
+  Scenario: This is a Scenario
+    Given step with table:
+      | aa | b  |
+      | a  | bb |
+`));
+	});
+
+	// The escape fixture is where run()'s two splitters (escape-aware width
+	// computation vs. the lookbehind used for comparison) can disagree, so it's
+	// the sharpest idempotency test: re-detecting on fixed output must find nothing.
+	it('produces output that re-detection finds no violations in (idempotent)', async function() {
+		const config = {examples: true, steps: true};
+		const {feature, pickles, file} = await linter.readAndParseFile('test/rules/table-align/escape.feature');
+		rule.run({feature, pickles, file}, config).forEach(error => rule.fix(error, file));
+
+		const tmpFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'gplint-table-align-')), 'fixed.feature');
+		fs.writeFileSync(tmpFile, file.lines.join(file.EOL));
+		const reparsed = await linter.readAndParseFile(tmpFile);
+
+		assert.lengthOf(rule.run(reparsed, config), 0);
 	});
 });

--- a/test/rules/table-align/weird-indent.feature
+++ b/test/rules/table-align/weird-indent.feature
@@ -1,0 +1,6 @@
+Feature: Feature with oddly-indented tables
+
+  Scenario: This is a Scenario
+    Given step with an over-indented table:
+            |a|bb|
+      |ccc|d|


### PR DESCRIPTION
Hi, and thank you for gplint - it's genuinely useful.
 
This pull request is unprompted, so I hope it's not an unwelcome surprise. It comes from a real need on my end: I wanted `gplint --fix` to tidy up misaligned tables on its own, but today the `table-align` rule can only flag them.

This PR would add that functionality. With `--fix`, misaligned tables get rewritten into their neatly lined-up form, following the same approach the other auto-fixable rules already use.

Autofixing is idempotent and cares about escaped pipes (`\|`). Separated to a refactor commit (first one) and functionality (second commit) for easier review. I've also added a bunch of tests.

I'd completely understand if this isn't a priority for you. But if you can find the time to review and merge it, I'd really appreciate your kindness in doing so.

Thanks for taking a look.

In case that matters, this was authored in collaboration with Claude Code (Opus 4.8).